### PR TITLE
Add Jest unit tests for presenters

### DIFF
--- a/backend-conectar/tests/app.controller.spec.ts
+++ b/backend-conectar/tests/app.controller.spec.ts
@@ -1,0 +1,18 @@
+import { AppController } from '@presenters/app.controller';
+import { AppService } from '@application/services/app.service';
+
+describe('AppController', () => {
+  let controller: AppController;
+  let service: jest.Mocked<AppService>;
+
+  beforeEach(() => {
+    service = { getHello: jest.fn().mockReturnValue('test') } as any;
+    controller = new AppController(service);
+  });
+
+  it('should return value from service', () => {
+    const result = controller.getHello();
+    expect(result).toBe('test');
+    expect(service.getHello).toHaveBeenCalled();
+  });
+});

--- a/backend-conectar/tests/auth/auth.controller.spec.ts
+++ b/backend-conectar/tests/auth/auth.controller.spec.ts
@@ -1,0 +1,35 @@
+import { AuthController } from '@presenters/auth/auth.controller';
+import { AuthService } from '@application/services/auth.service';
+import { LoginDTO } from '@application/dtos/login.dto';
+import { Response } from 'express';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let service: jest.Mocked<AuthService>;
+  let res: Response;
+
+  beforeEach(() => {
+    service = { signIn: jest.fn() } as any;
+    controller = new AuthController(service);
+    res = { cookie: jest.fn() } as any;
+  });
+
+  it('should login and set cookie', async () => {
+    const body: LoginDTO = { username: 'john', password: '123' };
+    const token = { accessToken: 'token' };
+    service.signIn.mockResolvedValue(token);
+
+    const result = await controller.login(body, res);
+
+    expect(service.signIn).toHaveBeenCalledWith('john', '123');
+    expect(res.cookie).toHaveBeenCalledWith('access_token', token, expect.any(Object));
+    expect(result).toEqual({ message: 'Login successful' });
+  });
+
+  it('should throw when service throws', async () => {
+    const body: LoginDTO = { username: 'john', password: '123' };
+    service.signIn.mockRejectedValue(new Error('invalid'));
+
+    await expect(controller.login(body, res)).rejects.toThrow('invalid');
+  });
+});

--- a/backend-conectar/tests/health-check/health-check.controller.spec.ts
+++ b/backend-conectar/tests/health-check/health-check.controller.spec.ts
@@ -1,0 +1,31 @@
+import { HealthCheckController } from '@presenters/health-check/health-check.controller';
+import { HealthCheckService } from '@application/services/health-check.service';
+import { IHealthCheckContract } from '@domain/contract/health-check.contract';
+
+describe('HealthCheckController', () => {
+  let controller: HealthCheckController;
+  let service: jest.Mocked<HealthCheckService>;
+
+  beforeEach(() => {
+    service = { getHealthCheck: jest.fn() } as any;
+    controller = new HealthCheckController(service);
+  });
+
+  it('should return health check info', () => {
+    const data: IHealthCheckContract = { message: 'ok' };
+    service.getHealthCheck.mockReturnValue(data);
+
+    const result = controller.getHello();
+
+    expect(result).toEqual(data);
+    expect(service.getHealthCheck).toHaveBeenCalled();
+  });
+
+  it('should throw when service fails', () => {
+    service.getHealthCheck.mockImplementation(() => {
+      throw new Error('fail');
+    });
+
+    expect(() => controller.getHello()).toThrow('fail');
+  });
+});

--- a/backend-conectar/tests/user/user.controller.spec.ts
+++ b/backend-conectar/tests/user/user.controller.spec.ts
@@ -1,0 +1,84 @@
+import { UserController } from '@presenters/user/user.controller';
+import { UserService } from '@application/services/user.service';
+import { CreateUserDto } from '@application/dtos/create-user.dto';
+import { UpdateUserDto } from '@application/dtos/update-user.dto';
+import { PaginationResponseDTO } from '@application/dtos/response-pagination.dto';
+
+describe('UserController', () => {
+  let controller: UserController;
+  let service: jest.Mocked<UserService>;
+
+  beforeEach(() => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as any;
+    controller = new UserController(service);
+  });
+
+  it('should create a user', async () => {
+    const dto: CreateUserDto = {
+      name: 'John',
+      email: 'john@test.com',
+      password: '123',
+      role: 'user',
+    };
+    const expected = { id: 1 } as any;
+    service.create.mockResolvedValue(expected);
+
+    const result = await controller.create(dto);
+
+    expect(service.create).toHaveBeenCalledWith(dto);
+    expect(result).toBe(expected);
+  });
+
+  it('should return paginated users', async () => {
+    const query = { page: '2', limit: '5' };
+    const expected: PaginationResponseDTO = {
+      users: [],
+      total: 0,
+      page: 2,
+      limit: 5,
+      totalPages: 0,
+    };
+    service.findAll.mockResolvedValue(expected);
+
+    const result = await controller.findAll(query);
+
+    expect(service.findAll).toHaveBeenCalledWith(2, 5);
+    expect(result).toBe(expected);
+  });
+
+  it('should return a single user', async () => {
+    const expected = { id: 1 } as any;
+    service.findOne.mockResolvedValue(expected);
+
+    const result = await controller.findOne(1);
+
+    expect(service.findOne).toHaveBeenCalledWith(1);
+    expect(result).toBe(expected);
+  });
+
+  it('should update a user', async () => {
+    const dto: UpdateUserDto = { name: 'Jane' };
+    const expected = { id: 1, name: 'Jane' } as any;
+    service.update.mockResolvedValue(expected);
+
+    const result = await controller.updateUser(1, dto);
+
+    expect(service.update).toHaveBeenCalledWith(1, dto);
+    expect(result).toBe(expected);
+  });
+
+  it('should delete a user', async () => {
+    service.delete.mockResolvedValue();
+
+    const result = await controller.deleteUser(1);
+
+    expect(service.delete).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ message: 'User Deleted Successfully' });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `app.controller`
- add tests for `auth.controller`
- add tests for `health-check.controller`
- add tests for `user.controller`

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6858111415188320aa786b6d1e7922f7